### PR TITLE
Target deadline fix

### DIFF
--- a/src/Declarations.cpp
+++ b/src/Declarations.cpp
@@ -1,7 +1,7 @@
 #include "Declarations.hpp"
 #include <string>
 
-const Burst::Version Burst::Settings::ProjectVersion = { 1, 3, 3 };
+const Burst::Version Burst::Settings::ProjectVersion = { 1, 3, 4 };
 
 #if defined MINING_CUDA
 const Burst::ProjectData Burst::Settings::Project = { "creepMiner CUDA", ProjectVersion };

--- a/src/Miner.cpp
+++ b/src/Miner.cpp
@@ -329,8 +329,11 @@ uint64_t Burst::Miner::getTargetDeadline() const
 	auto targetDeadline = targetDeadline_;
 	auto manualTargetDeadline = MinerConfig::getConfig().getTargetDeadline();
 
-	if (manualTargetDeadline > 0)
-		targetDeadline = targetDeadline < manualTargetDeadline ? targetDeadline : manualTargetDeadline;
+	if (targetDeadline == 0)
+		targetDeadline = manualTargetDeadline;
+	else if (targetDeadline > manualTargetDeadline &&
+		manualTargetDeadline > 0)
+		targetDeadline = manualTargetDeadline;
 
 	return targetDeadline;
 }


### PR DESCRIPTION
Manual target deadline ("targetDeadline" in config) was ignored if
pool/wallet target deadline == 0