### PR TITLE
Implemented dynamic targetDL

### DIFF
--- a/src/MinerUtil.cpp
+++ b/src/MinerUtil.cpp
@@ -571,7 +571,7 @@ Poco::JSON::Object Burst::createJsonConfig()
 	json.set("miningInfoUrlPort", std::to_string(MinerConfig::getConfig().getMiningInfoUrl().getPort()));
 	json.set("walletUrl", MinerConfig::getConfig().getWalletUrl().getCanonical(true));
 	json.set("walletUrlPort", std::to_string(MinerConfig::getConfig().getWalletUrl().getPort()));
-	json.set("totalPlotSize", memToString(PlotSizes::getTotal(PlotSizes::Type::Combined) * 1024 * 1024 * 1024, 2));
+	json.set("totalPlotSize", memToString(PlotSizes::getTotalBytes(PlotSizes::Type::Combined), 2));
 	json.set("timeout", MinerConfig::getConfig().getTimeout());
 	json.set("bufferSize", memToString(MinerConfig::getConfig().getMaxBufferSize(), 0));
 	json.set("bufferSizeRaw", std::to_string(MinerConfig::getConfig().getMaxBufferSizeRaw()));

--- a/src/mining/Miner.cpp
+++ b/src/mining/Miner.cpp
@@ -299,6 +299,26 @@ void Burst::Miner::updateGensig(const std::string& gensigStr, Poco::UInt64 block
 		const auto difficultyDifference = data_.getDifficultyDifference();
 		std::string diffiultyDifferenceToString;
 
+		// Get Difficulty, submitProbability and total Plotsize for targetDL calculation
+		const float difficultyFl = block->getDifficultyFloat();
+		const float tarDLFac = MinerConfig::getConfig().getTargetDLFactor();
+		float totAccPlotsize = static_cast<float>( PlotSizes::getTotalBytes(PlotSizes::Type::Combined) ) / 1024.f / 1024.f / 1024.f / 1024.f;
+
+		std::cout << " total Plot Size: " << totAccPlotsize << std::endl;
+		Poco::UInt64 blockTargetDeadline;
+		if (totAccPlotsize > 0)
+			blockTargetDeadline = tarDLFac * difficultyFl / totAccPlotsize;
+		else
+			blockTargetDeadline = 8000000000;
+		// Calculate targetDL for this round if a submitProbability is given
+		if (MinerConfig::getConfig().getSubmitProbability() > 0.) 
+		{
+			if( blockTargetDeadline < MinerConfig::getConfig().getTargetDeadline(TargetDeadlineType::Pool) )
+				MinerConfig::getConfig().setTargetDeadline( blockTargetDeadline , TargetDeadlineType::Local);
+			else
+				MinerConfig::getConfig().setTargetDeadline( MinerConfig::getConfig().getTargetDeadline(TargetDeadlineType::Pool) , TargetDeadlineType::Local);
+		}
+
 		if (difficultyDifference < 0)
 			diffiultyDifferenceToString = numberToString(difficultyDifference);
 		else if (difficultyDifference == 0)
@@ -311,11 +331,13 @@ void Burst::Miner::updateGensig(const std::string& gensigStr, Poco::UInt64 block
 			"scoop#     \t%Lu\n"
 			"baseTarget#\t%s\n"
 			"gensig     \t%s\n"
-			"difficulty \t%s (%s)\n" +
+			"difficulty \t%s (%s)\n"
+			"targetDL \t%s\n" +
 			std::string(50, '-'),
 			numberToString(blockHeight), block->getScoop(), numberToString(baseTarget), createTruncatedString(getGensigStr(), 14, 32),
 			numberToString(difficulty),
-			diffiultyDifferenceToString
+			diffiultyDifferenceToString,
+			numberToString(MinerConfig::getConfig().getTargetDeadline())
 		);
 
 		data_.getBlockData()->refreshBlockEntry();

--- a/src/mining/Miner.cpp
+++ b/src/mining/Miner.cpp
@@ -311,10 +311,12 @@ void Burst::Miner::updateGensig(const std::string& gensigStr, Poco::UInt64 block
 		// Calculate targetDL for this round if a submitProbability is given
 		if (MinerConfig::getConfig().getSubmitProbability() > 0.) 
 		{
-			if( blockTargetDeadline < MinerConfig::getConfig().getTargetDeadline(TargetDeadlineType::Pool) )
+			const Poco::UInt64 poolDeadline = MinerConfig::getConfig().getTargetDeadline(TargetDeadlineType::Pool);
+
+			if( blockTargetDeadline < poolDeadline || poolDeadline == 0 )
 				MinerConfig::getConfig().setTargetDeadline( blockTargetDeadline , TargetDeadlineType::Local);
 			else
-				MinerConfig::getConfig().setTargetDeadline( MinerConfig::getConfig().getTargetDeadline(TargetDeadlineType::Pool) , TargetDeadlineType::Local);
+				MinerConfig::getConfig().setTargetDeadline( poolDeadline , TargetDeadlineType::Local);
 		}
 
 		if (difficultyDifference < 0)
@@ -335,7 +337,7 @@ void Burst::Miner::updateGensig(const std::string& gensigStr, Poco::UInt64 block
 			numberToString(blockHeight), block->getScoop(), numberToString(baseTarget), createTruncatedString(getGensigStr(), 14, 32),
 			numberToString(difficulty),
 			diffiultyDifferenceToString,
-			numberToString(MinerConfig::getConfig().getTargetDeadline())
+			deadlineFormat(MinerConfig::getConfig().getTargetDeadline())
 		);
 
 		data_.getBlockData()->refreshBlockEntry();

--- a/src/mining/Miner.cpp
+++ b/src/mining/Miner.cpp
@@ -303,8 +303,6 @@ void Burst::Miner::updateGensig(const std::string& gensigStr, Poco::UInt64 block
 		const float difficultyFl = block->getDifficultyFloat();
 		const float tarDLFac = MinerConfig::getConfig().getTargetDLFactor();
 		float totAccPlotsize = static_cast<float>( PlotSizes::getTotalBytes(PlotSizes::Type::Combined) ) / 1024.f / 1024.f / 1024.f / 1024.f;
-
-		std::cout << " total Plot Size: " << totAccPlotsize << std::endl;
 		Poco::UInt64 blockTargetDeadline;
 		if (totAccPlotsize > 0)
 			blockTargetDeadline = tarDLFac * difficultyFl / totAccPlotsize;

--- a/src/mining/MinerConfig.hpp
+++ b/src/mining/MinerConfig.hpp
@@ -273,7 +273,7 @@ namespace Burst
 		Url urlWallet_;
 		bool startServer_ = true;
 		Url serverUrl_{"http://127.0.0.1:8080"};
-		float targetDLFactor_ = 0.0f;
+		float targetDLFactor_ = 1.0f;
 		float submitProbability_ = 0.999f;
 		Poco::UInt64 targetDeadline_ = 0, targetDeadlinePool_ = 0;
 		unsigned miningIntensity_ = 0;

--- a/src/mining/MinerConfig.hpp
+++ b/src/mining/MinerConfig.hpp
@@ -153,6 +153,8 @@ namespace Burst
 
 
 		Url getServerUrl() const;
+		float getSubmitProbability() const;
+		float getTargetDLFactor() const;
 		Poco::UInt64 getTargetDeadline(TargetDeadlineType type = TargetDeadlineType::Combined) const;
 		unsigned getMiningIntensity(bool real = true) const;
 		bool forPlotDirs(std::function<bool(PlotDir&)> traverseFunction) const;
@@ -200,6 +202,7 @@ namespace Burst
 		void setBufferSize(Poco::UInt64 bufferSize);
 		void setMaxSubmissionRetry(unsigned value);
 		void setTimeout(float value);
+		void setSubmitProbability(float subP);
 		void setTargetDeadline(const std::string& target_deadline, TargetDeadlineType type);
 		void setTargetDeadline(Poco::UInt64 target_deadline, TargetDeadlineType type);
 		void setMininigIntensity(unsigned intensity);
@@ -270,6 +273,8 @@ namespace Burst
 		Url urlWallet_;
 		bool startServer_ = true;
 		Url serverUrl_{"http://127.0.0.1:8080"};
+		float targetDLFactor_ = 0.0f;
+		float submitProbability_ = 0.999f;
 		Poco::UInt64 targetDeadline_ = 0, targetDeadlinePool_ = 0;
 		unsigned miningIntensity_ = 0;
 		std::string plotsHash_;

--- a/src/mining/MinerData.cpp
+++ b/src/mining/MinerData.cpp
@@ -261,6 +261,11 @@ Poco::UInt64 Burst::BlockData::getDifficulty() const
 	return 18325193796 / getBasetarget();
 }
 
+float Burst::BlockData::getDifficultyFloat() const
+{
+	return 18325193796.0f / static_cast<float>( getBasetarget() );
+}
+
 std::shared_ptr<Burst::Account> Burst::BlockData::getLastWinner() const
 {
 	return lastWinner_;

--- a/src/mining/MinerData.hpp
+++ b/src/mining/MinerData.hpp
@@ -70,6 +70,7 @@ namespace Burst
 		Poco::UInt64 getScoop() const;
 		Poco::UInt64 getBasetarget() const;
 		Poco::UInt64 getDifficulty() const;
+		float getDifficultyFloat() const;
 		std::shared_ptr<Account> getLastWinner() const;
 		
 		const GensigData& getGensig() const;

--- a/src/plots/PlotSizes.cpp
+++ b/src/plots/PlotSizes.cpp
@@ -49,7 +49,29 @@ Poco::UInt64 Burst::PlotSizes::get(const Poco::Net::IPAddress& ip)
 	return 0;
 }
 
-Poco::UInt64 Burst::PlotSizes::getTotal(const Type type, const Poco::UInt64 maxAge)
+Poco::UInt64 Burst::PlotSizes::getTotal(const Type type, const Poco::UInt64 maxAge) 
+{
+	Poco::ScopedLock<Poco::Mutex> lock{mutex_};
+
+	Poco::UInt64 sum = 0;
+
+	for (auto& size : sizes_)
+	{
+		if (maxAge == 0 || size.second.age <= maxAge)
+		{
+			if (type == Type::Local && size.second.local)
+				sum += size.second.size;
+			else if (type == Type::Remote && !size.second.local)
+				sum += size.second.size;
+			else if (type == Type::Combined)
+				sum += size.second.size;
+		}
+	}
+
+	return sum / 1024 / 1024 / 1024; //returns total plotsize in GB
+}
+
+Poco::UInt64 Burst::PlotSizes::getTotalBytes(const Type type, const Poco::UInt64 maxAge)
 {
 	Poco::ScopedLock<Poco::Mutex> lock{mutex_};
 

--- a/src/plots/PlotSizes.hpp
+++ b/src/plots/PlotSizes.hpp
@@ -24,6 +24,7 @@
 #include <map>
 #include <Poco/Mutex.h>
 #include <Poco/Net/IPAddress.h>
+#include <iostream>
 
 namespace Burst
 {
@@ -63,6 +64,7 @@ namespace Burst
 		 * \return The total amount of plot size in GB.
 		 */
 		static Poco::UInt64 getTotal(Type type, Poco::UInt64 maxAge = 10);
+		static Poco::UInt64 getTotalBytes(Type type, Poco::UInt64 maxAge = 10);
 
 		/**
 		 * \brief Adds one round to all plots sizes.

--- a/src/plots/PlotSizes.hpp
+++ b/src/plots/PlotSizes.hpp
@@ -24,7 +24,6 @@
 #include <map>
 #include <Poco/Mutex.h>
 #include <Poco/Net/IPAddress.h>
-#include <iostream>
 
 namespace Burst
 {

--- a/src/webserver/RequestHandler.cpp
+++ b/src/webserver/RequestHandler.cpp
@@ -605,7 +605,7 @@ void Burst::RequestHandler::submitNonce(Poco::Net::HTTPServerRequest& request, P
 		);
 
 		if (MinerConfig::getConfig().isCumulatingPlotsizes())
-			PlotSizes::set(request.clientAddress().host(), capacity, false);
+			PlotSizes::set(request.clientAddress().host(), capacity * 1024 * 1024 * 1024, false);
 
 		if (blockheight != miner.getBlockheight())
 		{


### PR DESCRIPTION
Implemented dynamic target deadline which is automatically calculated at every round start. (from total plotsize, round difficulty, and a new input paramter "submitProbability" which is set to 0.999 by default)
- addes variables submitProbability, targetDLFactor to MinerConfig
- added getDifficultyFloat() to MinerData
- added targetDL calculation at round start as well as aoutput of calculated
  targetDL along with block information
- changed unit of sizes_ in PlotSizes from GB to Bytes ( removed / 1024^3 in MinerConfig )
- added *1024^3 at one point in RequestHandler to switch from GB to Bytes
- added getTotalBytes(...) to PlotSizes
- replaced getTotal(...)*1024^3 with getTotalBytes(...) in MinerUtil