### PR TITLE
Allow conan method to be turned off

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,6 +190,11 @@ endif ()
 ##################################################################
 target_link_libraries(creepMiner ${CONAN_LIBS})
 
+if (NOT USE_CONAN)
+  find_package(Poco REQUIRED Foundation Util Net Crypto NetSSL)
+  target_link_libraries(creepMiner ${Poco_LIBRARIES})
+endif()
+
 if (USE_OPENCL)
 	target_link_libraries(creepMiner ${OpenCL_LIBRARY})
 endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,14 +40,21 @@ add_definitions(-DVERSION_MAJOR=${VERSION_MAJOR}
 				-DVERSION_MINOR=${VERSION_MINOR}
 				-DVERSION_BUILD=${VERSION_BUILD})
 
-# init conan
-if (CONAN_DEBUG)
-	include(conan/debug/conanbuildinfo.cmake)
-else ()
-	include(conanbuildinfo.cmake)
-endif ()
+##################################################################
+# using Conan for dependencies
+##################################################################
+option(USE_CONAN "If ON, Conan will be used to satisfy OpenSSL,POCO,and zlib dependency" ON)
 
-conan_basic_setup()
+if (USE_CONAN)
+  # init conan
+  if (CONAN_DEBUG)
+    include(conan/debug/conanbuildinfo.cmake)
+  else ()
+    include(conanbuildinfo.cmake)
+  endif ()
+
+  conan_basic_setup()
+endif ()
 
 ##################################################################
 # CPU architecture (only for Unix/Mac)

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -4,18 +4,20 @@ Pronunciation /ˈɪʃuː/ /ˈɪsjuː/
 An important topic or problem for debate or discussion.
 ```
 
-Please use the **search** function before you do so! Maybe your issue is already created by someone else. Also read the [**wiki pages**](https://github.com/Creepsky/creepMiner/wiki).
+Please use the **search** function! Maybe your issue is already created by someone else. Also read the [**wiki pages**](https://github.com/Creepsky/creepMiner/wiki).
 
 If you have a **question** about the miner:
 - please post only miner related questions
+- be precise (questions like 'Dude, it is slow for me, why?' will be closed)
 
 If you have a **problem** with the miner:
 - can you fix it yourself? If you can, please open a [pull request](https://help.github.com/articles/about-pull-requests/) - thank you!
 - please post only general problems, not individual ones; otherhwise see [can you help me with...?](https://github.com/Creepsky/creepMiner/wiki/FAQ#can-you-help-me-with)
+- use the [**latest release**](https://github.com/Creepsky/creepMiner/releases/latest), your issue may be solved already
 - describe the problem as accurately as possible
 - describe all steps to get to your problem so it can be traced - otherwise it is nearly impossible to fix it!
-- provide additional information like the name of your **OS**, the miner **version**
-- attach **log files** and **screenshots**
+- provide additional information like the name of your **OS**, the miner **version**, your **gcc version**, ...
+- attach **log files**, **screenshots** and your **config-file**
 
 If you want a **new feature** in the miner:
 - can you add it yourself? If you can, please open a [pull request](https://help.github.com/articles/about-pull-requests/) - thank you!

--- a/src/webserver/RequestHandler.cpp
+++ b/src/webserver/RequestHandler.cpp
@@ -93,7 +93,7 @@ void Burst::RequestHandler::WebsocketRequestHandler::handleRequest(Poco::Net::HT
 	try
 	{
 		WebSocket ws(request, response);
-		poco_debug(MinerLogger::server, "WebSocket connection established.");
+		log_debug(MinerLogger::server, "WebSocket connection established.");
 
 		try
 		{
@@ -161,7 +161,7 @@ void Burst::RequestHandler::WebsocketRequestHandler::handleRequest(Poco::Net::HT
 		}
 		while (!close && (flags & WebSocket::FRAME_OP_BITMASK) != WebSocket::FRAME_OP_CLOSE);
 		ws.shutdown();
-		poco_debug(MinerLogger::server, "WebSocket connection closed.");
+		log_debug(MinerLogger::server, "WebSocket connection closed.");
 	}
 	catch (WebSocketException& exc)
 	{


### PR DESCRIPTION
I added another parameter that turned off conan, but conan is the default.

This allows others to provide poco libraries from another source.  I current make a docker version of creep miner and this allows me to build it for docker.
eg: cmake CMakeLists.txt -DCMAKE_BUILD_TYPE=RELEASE -DUSE_CONAN=OFF

Let me know if you want me to change something.