### PR TITLE
Bugfixes for Overlap and Integrity Check

### DIFF
--- a/resources/public/js/block.js
+++ b/resources/public/js/block.js
@@ -267,7 +267,7 @@ function newBlock(json) {
 	lastWinnerContainer.hide();
 	avgDeadline.html(json["deadlinesAvg"]);
 	deadlinePerformance.html(Math.round(json["deadlinePerformance"]*1000)/1000 + " TB");
-	roundsSubmitted.html(json["nRoundsSubmitted"] + " / " + maxHistoricalBlocks);
+	roundsSubmitted.html(json["nRoundsSubmitted"] + " / " + json["numHistoricals"] + " ( " + maxHistoricalBlocks +" max. )");
 	wonBlocks.html(json["blocksWon"]);
 	lowestDiff.html(json["lowestDifficulty"]["value"] + " <small>@" + json["lowestDifficulty"]["blockheight"] + "</small>");
 	highestDiff.html(json["highestDifficulty"]["value"] + " <small>@" + json["highestDifficulty"]["blockheight"] + "</small>");

--- a/resources/public/js/plotfiles.js
+++ b/resources/public/js/plotfiles.js
@@ -151,7 +151,7 @@ function checkPlotFile(account, start_nonce, nonces, staggersize, path) {
 		var butId = account + "_" + start_nonce + "_" + nonces + "_" + staggersize;
 		var buttonElement=document.getElementById(butId);
 		buttonElement.innerHTML="<span style='width=100%'>...</span>";
-		$.get("/checkPlotFile/" + path);
+		$.get(encodeURI("/checkPlotFile/" + path));
 	}
 	}
 	

--- a/src/MinerUtil.cpp
+++ b/src/MinerUtil.cpp
@@ -680,6 +680,7 @@ Poco::JSON::Object Burst::createJsonNewBlock(const MinerData& data)
 		sumDiffs += blockDiff;
 	}
 
+	json.set("numHistoricals", std::to_string(nDiffs));
 	json.set("meanDifficulty",std::to_string(sumDiffs/static_cast<double>(nDiffs)));
 	json.set("difficultyHistory", difficultyHistory);
 	json.set("bestDeadlines", bestDeadlines);

--- a/src/mining/Miner.cpp
+++ b/src/mining/Miner.cpp
@@ -314,6 +314,7 @@ void Burst::Miner::updateGensig(const std::string& gensigStr, Poco::UInt64 block
 
 	// setup new block-data
 	auto block = data_.startNewBlock(blockHeight, baseTarget, gensigStr, MinerConfig::getConfig().getTargetDeadline(TargetDeadlineType::Local));
+	setIsProcessing(true);
 
 	// printing block info and transfer it to local server
 	{
@@ -412,6 +413,11 @@ bool Burst::Miner::hasBlockData() const
 Poco::UInt64 Burst::Miner::getScoopNum() const
 {
 	return data_.getCurrentScoopNum();
+}
+
+bool Burst::Miner::isProcessing() const
+{
+	return isProcessing_;
 }
 
 Burst::SubmitResponse Burst::Miner::addNewDeadline(Poco::UInt64 nonce, Poco::UInt64 accountId, Poco::UInt64 deadline, Poco::UInt64 blockheight,
@@ -687,6 +693,7 @@ void Burst::Miner::onBenchmark(Poco::Timer& timer)
 void Burst::Miner::onRoundProcessed(Poco::UInt64 blockHeight, double roundTime)
 {
 	const auto block = data_.getBlockData();
+	setIsProcessing(false);
 
 	if (block == nullptr || block->getBlockheight() != blockHeight)
 		return;
@@ -851,4 +858,11 @@ void Burst::Miner::rescanPlotfiles()
 		// then we send all plot dirs and files
 		data_.getBlockData()->refreshPlotDirs();
 	}
+}
+
+void Burst::Miner::setIsProcessing(bool isProc)
+{
+	Poco::Mutex::ScopedLock lock(worker_mutex_);
+
+	isProcessing_ = isProc;
 }

--- a/src/mining/Miner.hpp
+++ b/src/mining/Miner.hpp
@@ -60,6 +60,7 @@ namespace Burst
 		bool wantRestart() const;
 
 		bool hasBlockData() const;
+		bool isProcessing() const;
 		Poco::UInt64 getScoopNum() const;
 		Poco::UInt64 getBaseTarget() const;
 		Poco::UInt64 getBlockheight() const;
@@ -86,6 +87,7 @@ namespace Burst
 		void setMaxPlotReader(unsigned max_reader);
 		static void setMaxBufferSize(Poco::UInt64 size);
 		void rescanPlotfiles();
+		void setIsProcessing(bool isProc);
 
 	private:
 		bool getMiningInfo();
@@ -101,7 +103,7 @@ namespace Burst
 		void onBenchmark(Poco::Timer& timer);
 		void onRoundProcessed(Poco::UInt64 blockHeight, double roundTime);
 
-		bool running_ = false, restart_ = false;
+		bool running_ = false, restart_ = false, isProcessing_ = false;
 		MinerData data_;
 		std::shared_ptr<PlotReadProgress> progressRead_, progressVerify_;
 		std::unique_ptr<Poco::Net::HTTPClientSession> miningInfoSession_;

--- a/src/mining/MinerConfig.cpp
+++ b/src/mining/MinerConfig.cpp
@@ -96,8 +96,14 @@ void Burst::MinerConfig::checkPlotOverlaps()
 				{
 					Poco::UInt64 overlap = startNonceOne + nonceCountOne - startNonceTwo;
 					if (nonceCountTwo < overlap) overlap = nonceCountTwo;
-					//std::cout << pathOne << " and " << pathTwo << " overlap by " << overlap << " nonces." << std::endl;
 					log_error(MinerLogger::miner, pathOne + " and " + pathTwo + " overlap by " + std::to_string(overlap) + " nonces.");
+					totalOverlaps++;
+				}
+				else if (startNonceOne >= startNonceTwo && startNonceOne < startNonceTwo + nonceCountTwo)
+				{
+					Poco::UInt64 overlap = startNonceTwo + nonceCountTwo - startNonceOne;
+					if (nonceCountOne < overlap) overlap = nonceCountOne;
+					log_error(MinerLogger::miner, pathTwo + " and " + pathOne + " overlap by " + std::to_string(overlap) + " nonces.");
 					totalOverlaps++;
 				}
 			}

--- a/src/plots/PlotGenerator.cpp
+++ b/src/plots/PlotGenerator.cpp
@@ -82,7 +82,7 @@ Poco::UInt64 Burst::PlotGenerator::generateAndCheck(Poco::UInt64 account, Poco::
 }
 
 
-float Burst::PlotGenerator::checkPlotfileIntegrity(std::string plotPath)
+float Burst::PlotGenerator::checkPlotfileIntegrity(std::string plotPath, Miner& miner)
 {
 	Poco::UInt64 account = Poco::NumberParser::parseUnsigned64(getAccountIdFromPlotFile(plotPath));
 	Poco::UInt64 startNonce = Poco::NumberParser::parseUnsigned64(getStartNonceFromPlotFile(plotPath));
@@ -101,6 +101,8 @@ float Burst::PlotGenerator::checkPlotfileIntegrity(std::string plotPath)
 	int noncesChecked = 0;		//counter for the case of nonceCount not devisible by checkNonces
 
 	for (Poco::UInt64 nonceInterval = startNonce; nonceInterval < startNonce + nonceCount; nonceInterval += nonceCount / checkNonces) {
+
+		while (miner.isProcessing()) Poco::Thread::sleep(1000);
 
 		Poco::UInt64 nonce = nonceInterval + randInt(gen) % (nonceCount / checkNonces);
 		if (nonce >= startNonce + nonceCount) nonce = startNonce + nonceCount - 1;

--- a/src/plots/PlotGenerator.hpp
+++ b/src/plots/PlotGenerator.hpp
@@ -35,7 +35,7 @@ namespace Burst
 	{
 	public:
 		static Poco::UInt64 generateAndCheck(Poco::UInt64 account, Poco::UInt64 nonce, const Miner& miner);
-		static float checkPlotfileIntegrity(std::string plotPath);
+		static float checkPlotfileIntegrity(std::string plotPath, Miner& miner);
 	};
 
 	/*template <typename TShabal>

--- a/src/webserver/MinerServer.cpp
+++ b/src/webserver/MinerServer.cpp
@@ -278,9 +278,9 @@ Poco::Net::HTTPRequestHandler* Burst::MinerServer::RequestFactory::createRequest
 		// check plot file
 		if (path_segments.front() == "checkPlotFile")
 			if (path_segments.size() > 1) {
-				return new LambdaRequestHandler([&](req_t& req, res_t& res)
+				return new LambdaRequestHandler([&, plotPathEnc = move(path_segments[1])](req_t& req, res_t& res)
 			{
-				RequestHandler::checkPlotfile(req, res, *server_);
+				RequestHandler::checkPlotfile(req, res, *server_, plotPathEnc);
 			});
 			}
 

--- a/src/webserver/MinerServer.cpp
+++ b/src/webserver/MinerServer.cpp
@@ -280,7 +280,7 @@ Poco::Net::HTTPRequestHandler* Burst::MinerServer::RequestFactory::createRequest
 			if (path_segments.size() > 1) {
 				return new LambdaRequestHandler([&, plotPathEnc = move(path_segments[1])](req_t& req, res_t& res)
 			{
-				RequestHandler::checkPlotfile(req, res, *server_, plotPathEnc);
+				RequestHandler::checkPlotfile(req, res, *server_->miner_, *server_, plotPathEnc);
 			});
 			}
 

--- a/src/webserver/RequestHandler.cpp
+++ b/src/webserver/RequestHandler.cpp
@@ -453,7 +453,7 @@ void Burst::RequestHandler::rescanPlotfiles(Poco::Net::HTTPServerRequest& reques
 	response.send();
 }
 
-void Burst::RequestHandler::checkPlotfile(Poco::Net::HTTPServerRequest& request, Poco::Net::HTTPServerResponse& response, MinerServer& server, std::string plotPathEnc)
+void Burst::RequestHandler::checkPlotfile(Poco::Net::HTTPServerRequest& request, Poco::Net::HTTPServerResponse& response, Miner& miner, MinerServer& server, std::string plotPathEnc)
 {
 	// first check the credentials
 	if (!checkCredentials(request, response))
@@ -468,7 +468,7 @@ void Burst::RequestHandler::checkPlotfile(Poco::Net::HTTPServerRequest& request,
 	std::string plotPath = "";
 	Poco::URI::decode(plotPathEnc, plotPath, false);
 
-	float plotIntegrity = PlotGenerator::checkPlotfileIntegrity(plotPath);
+	float plotIntegrity = PlotGenerator::checkPlotfileIntegrity(plotPath, miner );
 
 	std::string plotID = getAccountIdFromPlotFile(plotPath) + "_" + getStartNonceFromPlotFile(plotPath) + "_" + getNonceCountFromPlotFile(plotPath) + "_" + getStaggerSizeFromPlotFile(plotPath);
 

--- a/src/webserver/RequestHandler.cpp
+++ b/src/webserver/RequestHandler.cpp
@@ -453,7 +453,7 @@ void Burst::RequestHandler::rescanPlotfiles(Poco::Net::HTTPServerRequest& reques
 	response.send();
 }
 
-void Burst::RequestHandler::checkPlotfile(Poco::Net::HTTPServerRequest& request, Poco::Net::HTTPServerResponse& response, MinerServer& server)
+void Burst::RequestHandler::checkPlotfile(Poco::Net::HTTPServerRequest& request, Poco::Net::HTTPServerResponse& response, MinerServer& server, std::string plotPathEnc)
 {
 	// first check the credentials
 	if (!checkCredentials(request, response))
@@ -465,8 +465,8 @@ void Burst::RequestHandler::checkPlotfile(Poco::Net::HTTPServerRequest& request,
 
 	log_information(MinerLogger::server, "Got request to check a file for corruption...");
 
-	std::string plotPath = request.getURI();
-	plotPath = plotPath.erase(0, 15);
+	std::string plotPath = "";
+	Poco::URI::decode(plotPathEnc, plotPath, false);
 
 	float plotIntegrity = PlotGenerator::checkPlotfileIntegrity(plotPath);
 

--- a/src/webserver/RequestHandler.hpp
+++ b/src/webserver/RequestHandler.hpp
@@ -229,7 +229,7 @@ namespace Burst
 		* \param miner The miner, which will propagate the changed config to his connected users.
 		* \param path The path of the plot file to check for corruption.
 		*/
-		void checkPlotfile(Poco::Net::HTTPServerRequest& request, Poco::Net::HTTPServerResponse& response,
+		void checkPlotfile(Poco::Net::HTTPServerRequest& request, Poco::Net::HTTPServerResponse& response, Miner& miner,
 			MinerServer& server, std::string plotPathEnc);
 
 		/**

--- a/src/webserver/RequestHandler.hpp
+++ b/src/webserver/RequestHandler.hpp
@@ -230,7 +230,7 @@ namespace Burst
 		* \param path The path of the plot file to check for corruption.
 		*/
 		void checkPlotfile(Poco::Net::HTTPServerRequest& request, Poco::Net::HTTPServerResponse& response,
-			MinerServer& server);
+			MinerServer& server, std::string plotPathEnc);
 
 		/**
 		 * \brief Checks the credentials for a request and compares them with the credentials set in the config file.


### PR DESCRIPTION
- integrity check now able to check files with spaces in the plot path (encodeURI)
- encodeURI also fixed an issue where the webinterface wasn't able to display the response from integrity check in some cases
- fixed the overlap check (didn't get all cases of overlaps before)
- two small changes to js files