### PR TITLE
Added support for recursing folders

### DIFF
--- a/src/mining/MinerConfig.cpp
+++ b/src/mining/MinerConfig.cpp
@@ -58,7 +58,7 @@ bool Burst::MinerConfig::rescanPlotfiles()
 	Poco::Mutex::ScopedLock lock(mutex_);
 
 	for (auto& plotDir : plotDirs_)
-		plotDir->rescan();
+		plotDir->rescan(getRecursiveScan());
 
 	const auto oldPlotsHash = plotsHash_;
 	recalculatePlotsHash();
@@ -405,7 +405,7 @@ bool Burst::MinerConfig::readConfigFile(const std::string& configPath)
 
 		submission_max_retry_ = getOrAdd(miningObj, "submissionMaxRetry", 10);
 		maxBufferSizeMB_ = getOrAdd(miningObj, "maxBufferSizeMB", 0u);
-
+		recursiveScan_ = getOrAdd(miningObj, "recursiveScan", false);
 		auto timeout = getOrAdd(miningObj, "timeout", 30);
 		timeout_ = static_cast<float>(timeout);
 
@@ -1157,6 +1157,11 @@ Poco::UInt64 Burst::MinerConfig::getMaxBufferSize() const
 Poco::UInt64 Burst::MinerConfig::getMaxBufferSizeRaw() const
 {
 	return maxBufferSizeMB_;
+}
+
+bool Burst::MinerConfig::getRecursiveScan() const
+{
+	return recursiveScan_;
 }
 
 void Burst::MinerConfig::setMininigIntensity(unsigned intensity)

--- a/src/mining/MinerConfig.hpp
+++ b/src/mining/MinerConfig.hpp
@@ -137,6 +137,7 @@ namespace Burst
 
 		Poco::UInt64 getMaxBufferSize() const;
 		Poco::UInt64 getMaxBufferSizeRaw() const;
+		bool getRecursiveScan() const;
 		float getReceiveTimeout() const;
 		float getSendTimeout() const;
 		float getTimeout() const;
@@ -289,6 +290,7 @@ namespace Burst
 		bool logUseColors_ = true;
 		bool steadyProgressBar_ = true;
 		bool fancyProgressBar_ = true;
+		bool recursiveScan_ = false;
 		unsigned wakeUpTime_ = 0;
 		std::string cpuInstructionSet_ = "AUTO";
 		std::string processorType_ = "CPU";

--- a/src/plots/Plot.hpp
+++ b/src/plots/Plot.hpp
@@ -197,7 +197,7 @@ namespace Burst
 		 * \brief Resets the list of all plot files and searches the directory again for them.
 		 * The unique hash value and the total size is also recalculated.
 		 */
-		void rescan();
+		void rescan(bool recurse);
 
 	private:
 		/**
@@ -207,7 +207,7 @@ namespace Burst
 		 * \param fileOrPath The path to the plotfile or plot directory.
 		 * \return true, if all plot files could be added.
 		 */
-		bool addPlotLocation(const std::string& fileOrPath);
+		bool addPlotLocation(const std::string& fileOrPath, bool recurse);
 
 		/**
 		 * \brief Adds a single plot file to the internal list of plotfiles, if it is a valid plotfile.


### PR DESCRIPTION
via new config option: "mining": { "recursiveScan": true }

Default is original behavior.

My C++ is rusty, forgive mistakes.
I was missing the SSL libs, and I only had a few minutes to make the changes. It builds, but can't link due to missing SSL libs.

Based off 2.7.16 branch (Last stable release)